### PR TITLE
SpiMaster now resets sclk back to CPOL idle state after each word transmission

### DIFF
--- a/cocotbext/spi/spi.py
+++ b/cocotbext/spi/spi.py
@@ -193,6 +193,7 @@ class SpiMaster:
                     await RisingEdge(self._sclk)
                 rx_word |= bool(self._miso.value.integer) << (self._config.word_width - 1 - k)
 
+            self._sclk <= self._config.cpol # set sclk back to idle state
             await self._SpiClock.stop()
 
             await Timer(self._SpiClock.period, units='step')


### PR DESCRIPTION
Previously, SCLK was not being reset to the expected idle state (in accordance with the value of CPOL) after each word sent.

Resolves #2 