### PR TITLE
[RFC/PoC] Proposal: Migrating from Bus Class to SystemVerilog Interface

### DIFF
--- a/cocotbext/spi/spi.py
+++ b/cocotbext/spi/spi.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2021 Spencer Chang
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
 from collections import deque
@@ -7,68 +9,18 @@ from dataclasses import dataclass
 from typing import Deque, Iterable, Optional, Tuple
 
 import cocotb
+from cocotb.handle import LogicObject
 from cocotb.triggers import Event, FallingEdge, First, RisingEdge, Timer
+from cocotbext.interface import Interface
 
 from .exceptions import SpiFrameError
 
 
-class Bus:
-    """
-    A simple bus class to manage signal connections.
-    This replaces the dependency on cocotb_bus for cocotb 2.0 compatibility.
-    """
-    def __init__(self, entity=None, prefix=None, signals=None, optional_signals=None, **kwargs):
-        self.entity = entity
-        self.prefix = prefix
-
-        # Combine required and optional signals
-        all_signals = {}
-        if signals:
-            all_signals.update(signals)
-        if optional_signals:
-            all_signals.update(optional_signals)
-
-        # Create signal attributes
-        for attr_name, signal_name in all_signals.items():
-            if prefix:
-                full_signal_name = f"{prefix}_{signal_name}"
-            else:
-                full_signal_name = signal_name
-
-            # Get the signal handle from the entity
-            signal_handle = getattr(entity, full_signal_name, None)
-            if signal_handle is None and attr_name in (optional_signals or {}):
-                # Optional signal not found, skip
-                continue
-
-            setattr(self, attr_name, signal_handle)
-
-
-class SpiBus(Bus):
-    def __init__(
-        self,
-        entity=None,
-        prefix=None,
-        sclk_name='sclk',
-        mosi_name='mosi',
-        miso_name='miso',
-        cs_name=None,
-        **kwargs,
-    ):
-        signals = {'sclk': sclk_name, 'mosi': mosi_name, 'miso': miso_name}
-        if cs_name is None:
-            optional_signals = {}
-        else:
-            optional_signals = {'cs': cs_name}
-        super().__init__(entity, prefix, signals, optional_signals=optional_signals, **kwargs)
-
-    @classmethod
-    def from_entity(cls, entity, **kwargs):
-        return cls(entity, **kwargs)
-
-    @classmethod
-    def from_prefix(cls, entity, prefix, **kwargs):
-        return cls(entity, prefix, **kwargs)
+class SpiBus(Interface):
+    sclk: LogicObject
+    miso: LogicObject
+    mosi: LogicObject
+    cs:   LogicObject | None = None
 
 
 @dataclass
@@ -92,7 +44,7 @@ class SpiMaster:
         self._sclk = bus.sclk
         self._mosi = bus.mosi
         self._miso = bus.miso
-        self.has_cs = hasattr(bus, 'cs')
+        self.has_cs = bus.cs is not None
         if self.has_cs:
             self._cs = bus.cs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dynamic = [
 ]
 dependencies = [
   "cocotb>=2.0.0",
+  "cocotbext-interface",
 ]
 [project.urls]
 repository = "https://github.com/schang412/cocotbext-spi"

--- a/tests/spi/test_spi.py
+++ b/tests/spi/test_spi.py
@@ -39,7 +39,7 @@ class TB:
         self.log = logging.getLogger("cocotb.tb")
         self.log.setLevel(logging.DEBUG)
 
-        self.bus = SpiBus.from_entity(dut, cs_name="ncs")
+        self.bus = SpiBus.from_pattern(dut, cs=dut.ncs)
 
         self.config = SpiConfig(
             word_width=word_width,

--- a/tests/spi_devices/ADI/adxl345/test_adxl345.py
+++ b/tests/spi_devices/ADI/adxl345/test_adxl345.py
@@ -19,7 +19,7 @@ class TB:
         self.log = logging.getLogger("cocotb.tb")
         self.log.setLevel(logging.DEBUG)
 
-        self.bus = SpiBus.from_entity(dut, cs_name="ncs")
+        self.bus = SpiBus.from_pattern(dut, cs=dut.ncs)
 
         self.config = SpiConfig(
             word_width=8,

--- a/tests/spi_devices/TI/ads8028/test_ads8028.py
+++ b/tests/spi_devices/TI/ads8028/test_ads8028.py
@@ -38,7 +38,7 @@ class TB:
         self.log = logging.getLogger("cocotb.tb")
         self.log.setLevel(logging.DEBUG)
 
-        self.bus = SpiBus.from_entity(dut, cs_name="ncs")
+        self.bus = SpiBus.from_pattern(dut, cs=dut.ncs)
 
         self.config = SpiConfig(
             word_width=16,

--- a/tests/spi_devices/TI/drv8304/test_drv8304.py
+++ b/tests/spi_devices/TI/drv8304/test_drv8304.py
@@ -38,7 +38,7 @@ class TB:
         self.log = logging.getLogger("cocotb.tb")
         self.log.setLevel(logging.DEBUG)
 
-        self.bus = SpiBus.from_entity(dut, cs_name="ncs")
+        self.bus = SpiBus.from_pattern(dut, cs=dut.ncs)
 
         self.config = SpiConfig(
             word_width=16,

--- a/tests/spi_devices/Trinamic/tmc4671/test_tmc4671.py
+++ b/tests/spi_devices/Trinamic/tmc4671/test_tmc4671.py
@@ -38,7 +38,7 @@ class TB:
         self.log = logging.getLogger("cocotb.tb")
         self.log.setLevel(logging.DEBUG)
 
-        self.bus = SpiBus.from_entity(dut, cs_name="ncs")
+        self.bus = SpiBus.from_pattern(dut, cs=dut.ncs)
 
         self.config = SpiConfig(
             word_width=40,

--- a/uv.lock
+++ b/uv.lock
@@ -73,10 +73,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/49/2d00e3518fcff0abc4c15207b1d14745420c6b4b4c7ece60d5c35717842e/cocotb_test-0.2.6.tar.gz", hash = "sha256:a4661948ca145eee6bccaf832174b5efb9f6d3420677157c04ade72bb2160692", size = 21254, upload-time = "2025-01-04T15:42:34.136Z" }
 
 [[package]]
+name = "cocotbext-interface"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cocotb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3a/eb6b7e55cf59c29c8cf786c017011d8f6d82cc272abf337956ec5333839c/cocotbext_interface-0.1.3.tar.gz", hash = "sha256:1f23be3996e7717e2f388467f85975617d83827f5df8558d10b3c0abf8987ee6", size = 21086, upload-time = "2026-03-05T08:00:07.57Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/fc/6f8525d763102c7ec1006ed80fca03f6cd7b8940928ced6f717e9fe4e5a7/cocotbext_interface-0.1.3-py3-none-any.whl", hash = "sha256:8b20b889f99796e4f1dd6ba6596e51d0ce9854d8530ac3970f3083f69fded61c", size = 13995, upload-time = "2026-03-05T08:00:06.496Z" },
+]
+
+[[package]]
 name = "cocotbext-spi"
 source = { editable = "." }
 dependencies = [
     { name = "cocotb" },
+    { name = "cocotbext-interface" },
 ]
 
 [package.dev-dependencies]
@@ -91,7 +104,10 @@ lint = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "cocotb", specifier = ">=2.0.0" }]
+requires-dist = [
+    { name = "cocotb", specifier = ">=2.0.0" },
+    { name = "cocotbext-interface" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This PR is a Proof of Concept (PoC) and a Proposal to transition our verification architecture from the current Bus class to a SystemVerilog interface model.

The goal of this spike is to evaluate the migration effort and gather feedback on a more modular structure. This initial phase focuses strictly on signal grouping to maintain parity with the existing Bus class functionality.

**The Value Proposition: Modular & Agnostic Verification**
The primary advantage of this refactor is the separation of the physical bus from the testbench logic:

* "Plug-and-Play" Interchangeability: By standardizing the API across similar interface types (e.g., various Stream implementations like AvalonST, Wishbone, I2C, SPI, and AXI stream), we can swap bus types without rewriting test logic.

* Framework Agility (pyuvm): This separation is a prerequisite for integrating with formal verification frameworks like pyuvm. By isolating the interface from the Driver and Monitor components, we make our verification IPs (VIPs) framework-agnostic.

* Scalability: Drivers and Monitors will interact with the API rather than specific signal names, drastically reducing the effort to port tests to new hardware variants.

**Proposed Roadmap (3-Step Migration)**
1. Phase 1 (This PR): Implement the interface for basic signal grouping. This is a 1-to-1 functional replacement for the Bus class to verify baseline connectivity.

2. Phase 2: Integrate clocking blocks to ensure race-free communication between Cocotb and the HDL simulator, resolving delta-cycle issues during signal drive/capture.

3. Phase 3: Define modports and the formal Interface API to enable seamless swapping of interface types.

```python
class SpiBus(Interface):
    sclk: LogicObject
    miso: LogicObject
    mosi: LogicObject
    cs:   LogicObject | None = None

    @clocking(clock="sclk")
    class cb_master:
        sclk: Output[LogicObject]
        miso: Input[LogicObject]
        mosi: Output[LogicObject]
        cs:   Output[LogicObject]

    @clocking(clock="sclk")
    class cb_slave:
        sclk: Input[LogicObject]
        miso: Output[LogicObject]
        mosi: Input[LogicObject]
        cs:   Input[LogicObject]


    @modport(clocking="cb_master")
    class master:
        reset:        Import[Callable]
        config:       Import[Callable]
        write:        Import[Callable]
        write_nowait: Import[Callable]
        read:         Import[Callable]
        read_nowait:  Import[Callable]
        wait:         Import[Callable]

    @modport(clocking="cb_slave")
    class slave:
        reset:        Import[Callable]
        config:       Import[Callable]

    def reset(self) -> None:
        ...

    def config(self) -> None:
        ...

    async def write(self, data: bytes) -> None:
        ...

    def write_nowait(self, data: bytes) -> None:
        ...

    async def read(self) -> bytes:
        ...

    def read_nowait(self) -> bytes:
        ...

    async def wait(self) -> None:
        ...
```

