### PR TITLE
fix: prevent hang in _transparent_shift() on simultaneous frame_end/clock edge

### DIFF
--- a/cocotbext/spi/spi.py
+++ b/cocotbext/spi/spi.py
@@ -353,16 +353,26 @@ class SpiSlaveBase(ABC):
         rx_word = 0
 
         frame_end = RisingEdge(self._cs) if self._config.cs_active_low else FallingEdge(self._cs)
-        propagate_out_delay = Timer(delay, unit=delay_units)
+        cs_deasserted = int(self._config.cs_active_low)  # 1 for active-low, 0 for active-high
 
         for k in range(num_bits):
-            f = await First(self._sclk.value_change, frame_end)
+            # Guard against simultaneity: if frame_end and the clock edge occur in the same
+            # timestep, First() may return either one. Check CS level after the wait so we
+            # never proceed into further waits with a frame_end that already fired.
+            await First(self._sclk.value_change, frame_end)
+            if int(self._cs.value) == cs_deasserted:
+                raise SpiFrameError("End of frame in the middle of a transaction")
+
             if not self._config.cpha:
                 # when CPHA=0, the first thing the slave should do is read in
                 rx_word |= int(self._mosi.value) << (num_bits - 1 - k)
                 most_recent_bit = int(self._mosi.value)
 
+                # Allocate a fresh Timer each iteration — Timer is one-shot and cannot be reused
+                propagate_out_delay = Timer(delay, unit=delay_units)
                 w = await First(propagate_out_delay, frame_end, self._sclk.value_change)
+                if int(self._cs.value) == cs_deasserted:
+                    raise SpiFrameError("Unexpected end of frame in the middle of a transaction")
 
                 if w != propagate_out_delay:
                     if w == frame_end:
@@ -372,14 +382,20 @@ class SpiSlaveBase(ABC):
 
                 self._miso.value = bool(most_recent_bit)
 
-            s = await First(self._sclk.value_change, frame_end)
+            await First(self._sclk.value_change, frame_end)
+            if int(self._cs.value) == cs_deasserted:
+                raise SpiFrameError("End of frame in the middle of a transaction")
 
             if self._config.cpha:
                 # when CPHA=1, the second thing we should do is read in
                 rx_word |= int(self._mosi.value) << (num_bits - 1 - k)
                 most_recent_bit = int(self._mosi.value)
 
+                # Allocate a fresh Timer each iteration — Timer is one-shot and cannot be reused
+                propagate_out_delay = Timer(delay, unit=delay_units)
                 w = await First(propagate_out_delay, frame_end, self._sclk.value_change)
+                if int(self._cs.value) == cs_deasserted:
+                    raise SpiFrameError("Unexpected end of frame in the middle of a transaction")
 
                 if w != propagate_out_delay:
                     if w == frame_end:
@@ -388,9 +404,6 @@ class SpiSlaveBase(ABC):
                         raise SpiFrameError("Unexpected edge of sclk while waiting to propagate next bit")
 
                 self._miso.value = bool(most_recent_bit)
-
-            if frame_end in (f, s):
-                raise SpiFrameError("End of frame in the middle of a transaction")
 
         return rx_word
 


### PR DESCRIPTION
Two related bugs in _transparent_shift():

1. Simultaneity hang: the previous code tracked the return values of First() in f and s, then checked 'if frame_end in (f, s)' at the end of the loop body. If frame_end and the SCLK edge occurred in the same simulation timestep, First() could return the clock edge rather than frame_end. The code would then proceed, and subsequent First() calls that included frame_end would wait forever for a trigger that had already fired.

   Fix: replace the end-of-loop f/s check with CS-level guards immediately after each First() wait. This catches end-of-frame regardless of which trigger First() happened to return.

2. Consumed Timer reuse: propagate_out_delay was allocated once outside the bit loop as Timer(delay, ...). A cocotb Timer is one-shot; once it fires on iteration k=0 it is consumed and will never fire again. Awaiting it on iteration k=1 would hang indefinitely.

   Fix: allocate a fresh Timer inside the loop, just before each await.